### PR TITLE
Move callback module to broadcast worker state

### DIFF
--- a/test/plumtree_SUITE.erl
+++ b/test/plumtree_SUITE.erl
@@ -394,7 +394,7 @@ start(_Case, Config, Options) ->
             end,
 
             %% configure plumtree
-            ok = rpc:call(Node, application, set_env, [plumtree, broadcast_mods, [plumtree_test_broadcast_handler]]),
+            ok = rpc:call(Node, application, set_env, [plumtree, broadcast_mod, plumtree_test_broadcast_handler]),
             %% reduce the broacast exchange period down to 1 second
             ok = rpc:call(Node, application, set_env, [plumtree, broadcast_exchange_timer, 1000]),
             %% initialize the test broadcast handler


### PR DESCRIPTION
Also stop sending it around on every single
message, each worker keeps the module name
in it’s state and uses that when needing to invoke
any of the behaviours methods