### PR TITLE
Drop stale outstanding lazy pushes

### DIFF
--- a/src/plumtree_broadcast_handler.erl
+++ b/src/plumtree_broadcast_handler.erl
@@ -31,6 +31,11 @@
 %% `false' otherwise
 -callback is_stale(any()) -> boolean().
 
+%% Return true if the first message argument (given the message id) is causally newer than the
+%% second message argument (given message id as well)
+%% `false' otherwise
+-callback is_stale(any(), any()) -> boolean().
+
 %% Return the message associated with the given message id. In some cases a message
 %% has already been sent with information that subsumes the message associated with the given
 %% message id. In this case, `stale' is returned.

--- a/test/plumtree_test_broadcast_handler.erl
+++ b/test/plumtree_test_broadcast_handler.erl
@@ -27,7 +27,7 @@
 %% plumtree_broadcast_handler callbacks
 -export([broadcast_data/1,
          merge/2,
-         is_stale/1,
+         is_stale/1, is_stale/2,
          graft/1,
          exchange/1]).
 
@@ -144,6 +144,15 @@ is_stale({Key, Context}) ->
         Existing ->
             plumtree_test_object:is_stale(Context, Existing)
     end.
+
+%% Return true if the first message argument (given the message id) is causally newer than the
+%% second message argument (given message id as well)
+%% `false' otherwise
+-spec is_stale(any(), any()) -> boolean().
+is_stale({Key, Context1}, {Key, Context2}) ->
+    %% returns true (stale) when context1 is causally newer or equal to context2
+    plumtree_test_object:descends(Context1, Context2);
+is_stale(_, _) -> false.
 
 %% Return the message associated with the given message id. In some cases a message
 %% has already been sent with information that subsumes the message associated with the given

--- a/test/plumtree_test_object.erl
+++ b/test/plumtree_test_object.erl
@@ -26,7 +26,8 @@
          modify/3,
          modify/4,
          is_stale/2,
-         reconcile/2]).
+         reconcile/2,
+         descends/2]).
 
 -type test_object()     :: dvvset:clock().
 -type test_context()    :: dvvset:vector().


### PR DESCRIPTION
Over the course of an execution a peer accumulates several
lazy pushes to be sent on the lazy tick. Meanwhile it will receive
lazy pushes from other peers, these messages might make some
of the lazy push messages irrelevant since they already subsume
the outstanding ones. The intuition here is that if someone tells me
something it is irrelevant for me to tell that someone a subset of that
thing.

Expose a new callback method that allows comparing two message ids
and return a boolean to inform wether the first subsumes the second
(ie. the first is causally newer than the second).